### PR TITLE
allow single archive in get archive function

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,14 +15,17 @@ function HyperdriveHttp (getArchive) {
     var archive = getArchive
     singleArchive = true
     getArchive = function (datUrl, cb) {
-      cb(null, archive)
+      cb(null, archive, true)
     }
   }
   var onrequest = function (req, res) {
     var datUrl = parse(req.url)
     if (!datUrl) return onerror(404, res)
     getArchive(datUrl, function (err, archive) {
-      if (err) return onerror(err)
+      if (err) {
+        console.error(err)
+        return onerror(404, res)
+      }
       archiveResponse(datUrl, archive, req, res)
     })
   }
@@ -38,20 +41,22 @@ function HyperdriveHttp (getArchive) {
     if (/\.changes$/.test(key)) {
       key = key.slice(0, -8)
       op = 'changes'
-      if (singleArchive) url = url.slice(0, -8)
     }
 
     try {
       encoding.decode(key)
     } catch (_) {
-      if (!singleArchive) return null
+      if (op === 'changes') url = url.slice(0, -8)
+      key = null
+      filename = url.slice(1)
+      singleArchive = true
     }
-    if (singleArchive) filename = url.slice(1)
 
     return {
       key: key,
       filename: filename,
-      op: op
+      op: op,
+      singleArchive: singleArchive
     }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,7 @@ Pass an archive lookup function for the first argument of `hyperdriveHttp`. The 
 datInfo = {
   key: archive.key,
   filename: someFile.txt,
-  op: 'get' // or 'changes'
+  op: 'get', // or 'changes'
+  singleArchive: false // user may be requesting single archive at root. you may or may not support this. if this is true, key will be null.
 }
 ```


### PR DESCRIPTION
This would allow a getArchive function on initiation but still a method for serving a single archive at the root. 

It'd be helpful to have this if the archive isn't available at initiation or you want to still serve other archives along with one at the root.

This is WIP. I need to test a bit more and clean up docs. 

I think this would be a breaking change. It would pass a null key to the getArchive function if a user accessed the root or a file without a key.
