### PR TITLE
Add POST /:archive? endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function HyperdriveHttp (getArchive) {
     }
   }
   var onrequest = function (req, res) {
-    var datUrl = parse(req.url)
+    var datUrl = parse(req)
     if (!datUrl) return onerror(404, res)
     getArchive(datUrl, function (err, archive) {
       if (err) return onerror(err)
@@ -28,15 +28,15 @@ function HyperdriveHttp (getArchive) {
 
   return onrequest
 
-  function parse (url) {
-    var segs = url.split('/').filter(Boolean)
+  function parse (req) {
+    var segs = req.url.split('/').filter(Boolean)
     var key = archive
       ? encoding.encode(archive.key)
       : segs.shift()
     var filename = segs.shift()
     var op = 'get'
 
-    if (/\.changes$/.test(url)) {
+    if (/\.changes$/.test(req.url)) {
       op = 'changes'
       filename = filename.replace(/\.changes$/, '')
     }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/joehand/hyperdrive-http",
   "devDependencies": {
+    "collect-stream": "^1.2.1",
     "hypercore": "^4.7.0",
     "hyperdrive": "^7.0.0",
     "memdb": "^1.3.1",

--- a/readme.md
+++ b/readme.md
@@ -71,11 +71,13 @@ Hyperdrive-http responds to any URL with a specific format. If the URL does cann
 
 * Get metadata for archive: `http://dat.haus/c5dbfe5521d8dddba683544ee4b1c7f6ce1c7b23bd387bd850397e4aaf9afbd9/`
 * Get file from archive: `http://dat.haus/c5dbfe5521d8dddba683544ee4b1c7f6ce1c7b23bd387bd850397e4aaf9afbd9/filename.pdf`
+* Upload file: `POST http://archive-example.com/` or `POST http://archive-example.com/c5dbfe5521d8dddba683544ee4b1c7f6ce1c7b23bd387bd850397e4aaf9afbd9`
 
 #### Single Archive Mode
 
 * Get metadata for archive: `http://archive-example.com/`
 * Get file from archive: `http://archive-example.com/filename.pdf`
+* Upload file: `POST http://archive-example.com/`
 
 #### Hypercore Mode
 


### PR DESCRIPTION
fixes https://github.com/juliangruber/dat.haus/issues/10

This is a simple implementation for now, we can add more later on.

Also, I had to remove validation of archive keys because now it's valid to POST to `https://dat.haus/` in multi archive mode.
