### PR TITLE
capture whole filename including dirs and add parsing tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,10 +112,7 @@ function archiveResponse (datUrl, archive, req, res) {
 }
 
 function onerror (status, res) {
-  if (typeof status !== 'number') {
-    // console.error(status)
-    status = 404
-  }
+  if (typeof status !== 'number') status = 404
   res.statusCode = status
   res.end()
 }

--- a/index.js
+++ b/index.js
@@ -33,15 +33,15 @@ function HyperdriveHttp (getArchive) {
     var key = archive
       ? encoding.encode(archive.key)
       : segs.shift()
-    var filename = segs.shift()
+    var filename = segs.join('/')
     var op = 'get'
 
     try {
       // check if we are serving archive at root
       key = key.replace(/\.changes$/, '')
-      encoding.decode(key)
+      encoding.encode(Buffer.from(key, 'hex'))
     } catch (e) {
-      if (!filename) filename = key
+      filename = segs.length ? [key, segs].join('/') : key
       key = null
     }
 
@@ -113,7 +113,7 @@ function archiveResponse (datUrl, archive, req, res) {
 
 function onerror (status, res) {
   if (typeof status !== 'number') {
-    console.error(status)
+    // console.error(status)
     status = 404
   }
   res.statusCode = status

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function HyperdriveHttp (getArchive) {
     try {
       // check if we are serving archive at root
       key = key.replace(/\.changes$/, '')
-      encoding.encode(Buffer.from(key, 'hex'))
+      encoding.decode(key)
     } catch (e) {
       filename = segs.length ? [key].concat(segs).join('/') : key
       key = null

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function HyperdriveHttp (getArchive) {
       key = key.replace(/\.changes$/, '')
       encoding.encode(Buffer.from(key, 'hex'))
     } catch (e) {
-      filename = segs.length ? [key, segs].join('/') : key
+      filename = segs.length ? [key].concat(segs).join('/') : key
       key = null
     }
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "callback-timeout": "^2.1.0",
-    "dat-encoding": "^3.0.0",
+    "dat-encoding": "^3.0.1",
     "mime": "^1.3.4",
     "ndjson": "^1.4.3",
     "pump": "^1.0.1",

--- a/test/misc.js
+++ b/test/misc.js
@@ -1,0 +1,71 @@
+var http = require('http')
+var url = require('url')
+var test = require('tape')
+var request = require('request')
+var hyperdriveHttp = require('..')
+
+var server = http.createServer()
+
+test('setup', function (t) {
+  server.listen(8001)
+  server.once('listening', function () {
+    t.end()
+  })
+})
+
+test('GET Parsing no key', function (t) {
+  t.plan(6)
+  var count = 0
+  var rootUrl = 'http://localhost:8001'
+  var fileTests = [ // parsed filename should match these
+    undefined,
+    'file.txt',
+    'dir/file.txt'
+  ]
+
+  var onrequest = hyperdriveHttp(function (info, cb) {
+    t.same(info.key, null, 'key is null')
+    t.same(info.filename, fileTests[count], 'file parse ok')
+    count++
+    if (count === fileTests.length) server.removeListener('request', onrequest)
+    cb(404)
+  })
+  server.on('request', onrequest)
+  fileTests.forEach(function (filePath) {
+    var getUrl = filePath ? url.resolve(rootUrl, filePath) : rootUrl
+    request.get(getUrl).on('error', function () {
+      return
+    })
+  })
+})
+
+test('GET Parsing with key', function (t) {
+  t.plan(6)
+  var count = 0
+  var rootUrl = 'http://localhost:8001'
+  var fileTests = [ // parsed filename should match these
+    '72072fab3d3f593453c1caed2b4b176b03af2f58ef725722c8937403997c03f8',
+    '72072fab3d3f593453c1caed2b4b176b03af2f58ef725722c8937403997c03f8/file.txt',
+    '72072fab3d3f593453c1caed2b4b176b03af2f58ef725722c8937403997c03f8/dir/file.txt'
+  ]
+
+  var onrequest = hyperdriveHttp(function (info, cb) {
+    var segs = fileTests[count].split('/')
+    t.same(info.key, segs.shift())
+    t.same(info.filename, segs.join('/'), 'file parse ok')
+    count++
+    if (count === fileTests.length) server.removeListener('request', onrequest)
+    cb(404)
+  })
+  server.on('request', onrequest)
+  fileTests.forEach(function (filePath) {
+    var getUrl = filePath ? url.resolve(rootUrl, filePath) : rootUrl
+    request.get(getUrl).on('error', function () {
+      return
+    })
+  })
+})
+
+test.onFinish(function () {
+  server.close()
+})

--- a/test/misc.js
+++ b/test/misc.js
@@ -55,17 +55,27 @@ test('GET Parsing with key', function (t) {
     var segs = fileTests[count].split('/')
     t.same(info.key, segs.shift())
     t.same(info.filename, segs.join('/'), 'file parse ok')
-    count++
     if (count === fileTests.length) server.removeListener('request', onrequest)
     cb(404)
   })
   server.on('request', onrequest)
-  fileTests.forEach(function (filePath) {
-    var getUrl = filePath ? url.resolve(rootUrl, filePath) : rootUrl
-    request.get(getUrl).on('error', function () {
-      return
+  next()
+
+  function next () {
+    testFile(fileTests[count], function () {
+      if (count === fileTests.length) return
+      next()
     })
-  })
+  }
+
+  function testFile (filePath, cb) {
+    var getUrl = filePath ? url.resolve(rootUrl, filePath) : rootUrl
+    request.get(getUrl)
+    .on('response', function () {
+      count++
+      cb()
+    })
+  }
 })
 
 test.onFinish(function () {

--- a/test/misc.js
+++ b/test/misc.js
@@ -14,13 +14,14 @@ test('setup', function (t) {
 })
 
 test('GET Parsing no key', function (t) {
-  t.plan(6)
+  t.plan(8)
   var count = 0
   var rootUrl = 'http://localhost:8001'
   var fileTests = [ // parsed filename should match these
     undefined,
     'file.txt',
-    'dir/file.txt'
+    'dir/file.txt',
+    'dir/subdir/file.txt'
   ]
 
   var onrequest = hyperdriveHttp(function (info, cb) {
@@ -40,13 +41,14 @@ test('GET Parsing no key', function (t) {
 })
 
 test('GET Parsing with key', function (t) {
-  t.plan(6)
+  t.plan(8)
   var count = 0
   var rootUrl = 'http://localhost:8001'
   var fileTests = [ // parsed filename should match these
     '72072fab3d3f593453c1caed2b4b176b03af2f58ef725722c8937403997c03f8',
     '72072fab3d3f593453c1caed2b4b176b03af2f58ef725722c8937403997c03f8/file.txt',
-    '72072fab3d3f593453c1caed2b4b176b03af2f58ef725722c8937403997c03f8/dir/file.txt'
+    '72072fab3d3f593453c1caed2b4b176b03af2f58ef725722c8937403997c03f8/dir/file.txt',
+    '72072fab3d3f593453c1caed2b4b176b03af2f58ef725722c8937403997c03f8/dir/subdir/file.txt'
   ]
 
   var onrequest = hyperdriveHttp(function (info, cb) {


### PR DESCRIPTION
It seems like we weren't capturing the subdirectories before (and they weren't in the tests). 

I added some basic parsing tests for GET requests too. We can extend those now pretty easily for other edge cases.
