### PR TITLE
Update index.js require package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var mime = require('mime')
 var range = require('range-parser')
 var qs = require('querystring')
 var corsify = require('corsify')
-var pkg = require('./package')
+var pkg = require('./package.json')
 
 module.exports = serve
 


### PR DESCRIPTION
Testing with `rollup` to bundle `dat` in a single `bundle.js`. By leaving out the extension of the package import `rollup` fails as it is interpreting the import as js, not json.