### PR TITLE
Fix live mode for subdirectories.

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function ondirectoryindex (archive, name, req, res, opts) {
     var script = `
       function liveUpdate () {
         var xhr = new XMLHttpRequest()
-        xhr.open("GET", "${name}?wait=${wait}", true)
+        xhr.open("GET", ".${name}?wait=${wait}", true)
         xhr.onload = function () {
           if (xhr.status !== 200) return onerror()
           document.open()


### PR DESCRIPTION
I have a server where I mount this middleware in a subfolder.

```js
let handler = hypeDriveHttp(archive), {live:true})
app.use('/sub', handler(req, res))
```

Express rewrites `req.url` to remove the `/sub` prefix, but the JS code here uses an absolute url.

This tiny fix allows me to use live mode.