### PR TITLE
Greenkeeper/mime 2.0.3

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function onfile (archive, name, req, res) {
 
     var r = req.headers.range && range(st.size, req.headers.range)[0]
     res.setHeader('Accept-Ranges', 'bytes')
-    res.setHeader('Content-Type', mime.lookup(name))
+    res.setHeader('Content-Type', mime.getType(name))
 
     if (r) {
       res.statusCode = 206

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "corsify": "^2.1.0",
     "directory-index-html": "^2.1.0",
-    "mime": "^1.3.4",
+    "mime": "^2.0.3",
     "pump": "^1.0.2",
     "range-parser": "^1.2.0"
   },


### PR DESCRIPTION
removes node v4 support, so I will wait to merge this.