### PR TITLE
Support fallback pages in dat.json

### DIFF
--- a/test/404.html
+++ b/test/404.html
@@ -1,0 +1,1 @@
+File Not Found Page

--- a/test/dat.json
+++ b/test/dat.json
@@ -1,0 +1,6 @@
+{
+  "title": "Application Title",
+  "description": "A short description of the app",
+  "fallback_page": "/public/404.html",
+  "web_root": "/public"
+}


### PR DESCRIPTION
Fixes #44 

How it works:

If there's a 404 for a file, instead of showing an error page, attempt to load the dat.json in the repo and try to redirect to the `fallback_page` if it exists.

Took care to prevent infinite loops if the file pointed to by `fallback_page` doesn't exist.

I had issues running the tests because none of the dependencies that were needed for them are in the package.json, but I've added a test in which should work.

Also, I think I got rid of the potential for a race condition with `archive2` not being populated in the setup.