### PR TITLE
Only set header if not already sent

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,9 @@ function waitFor (archive, until, cb) { // this feels a bit hacky, TODO: make le
 
 function onerror (res, status, err) {
   res.statusCode = status
-  res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+  if (!res.headersSent) {
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+  }
   res.end(err.stack)
 }
 


### PR DESCRIPTION
If I request a file within a dat that doesn't exist I get `NodeError: Cannot set headers after they are sent to the client`. This causes my dat gateway server to crash without being able to return a 404.